### PR TITLE
Safe load/unload calls

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,8 +48,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    // implementation ('es.situm:situm-wayfinding:0.19.1-alpha@aar') {
-    implementation ('es.situm:situm-wayfinding-release-0.20.0-flutter-0.6:0.20.0-alpha@aar') {
+    implementation ('es.situm:situm-wayfinding-release-0.20.0-flutter-0.7:0.20.0-alpha@aar') {
         transitive = true
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation ('es.situm:situm-wayfinding-release-0.20.0-flutter-0.7:0.20.0-alpha@aar') {
+    implementation ('es.situm:situm-wayfinding-release-0.20.0-flutter-0.8:0.20.0-alpha@aar') {
         transitive = true
     }
 }

--- a/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/FlutterCommunicationManager.kt
+++ b/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/FlutterCommunicationManager.kt
@@ -22,16 +22,20 @@ class FlutterCommunicationManager {
             SitumSdk.communicationManager()
                 .fetchIndoorPOIsFromBuilding(buildingId, object : Handler<Collection<Poi>> {
                     override fun onSuccess(pois: Collection<Poi>) {
+                        Log.d(TAG, "Getting POI $poiId.")
                         for (poi in pois) {
                             if (poiId == poi.identifier) {
+                                Log.d(TAG, "Found POI $poiId.")
                                 callback.onSuccess(poi)
                                 return
                             }
                         }
+                        Log.d(TAG, "POI $poiId not found.")
                         callback.onError("Poi with id=$poiId not found for building with id=$buildingId")
                     }
 
                     override fun onFailure(error: Error) {
+                        Log.e(TAG, "Error getting POI $poiId.")
                         callback.onError(error.message)
                     }
                 })

--- a/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/FlutterCommunicationManager.kt
+++ b/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/FlutterCommunicationManager.kt
@@ -1,5 +1,6 @@
 package com.situm.situm_flutter_wayfinding
 
+import android.util.Log
 import es.situm.sdk.SitumSdk
 import es.situm.sdk.error.Error
 import es.situm.sdk.model.cartography.Poi
@@ -9,6 +10,8 @@ import es.situm.sdk.utils.Handler
 class FlutterCommunicationManager {
 
     companion object {
+        const val TAG = "Situm>"
+
         /**
          * Get a Poi using both Building and Poi identifiers.
          * @param buildingId The building id.

--- a/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/SitumFlutterSDKPlugin.kt
+++ b/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/SitumFlutterSDKPlugin.kt
@@ -146,7 +146,6 @@ class SitumFlutterSDKPlugin : FlutterPlugin, ActivityAware, MethodChannel.Method
         val optionsBuilder = NetworkOptionsImpl.Builder()
         val optionsMap = (arguments["optionsMap"] ?: emptyMap<String, Any>()) as Map<String, Any>
         if (optionsMap.containsKey("preloadImages")) {
-            Log.d("ATAG", "Contains preloadImages parameter")
             optionsBuilder.setPreloadImages(optionsMap["preloadImages"] as Boolean)
         }
         val config = CommunicationConfigImpl(optionsBuilder.build())

--- a/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/SitumMapLibraryLoader.kt
+++ b/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/SitumMapLibraryLoader.kt
@@ -13,6 +13,8 @@ class SitumMapLibraryLoader private constructor(
 ) {
 
     companion object {
+        const val TAG = "Situm>"
+
         var loaded = false
         private var library: SitumMapsLibrary? = null
         private var instance: SitumMapLibraryLoader? = null
@@ -27,16 +29,16 @@ class SitumMapLibraryLoader private constructor(
     private val handler = android.os.Handler(Looper.getMainLooper())
 
     fun load(flutterLibrarySettings: FlutterLibrarySettings, callback: Callback) {
-        Log.d("Situm>", "PlatformView load called!")
+        Log.d(TAG, "PlatformView load called!")
         if (loaded) { // Manage this case, but it should not happen.
-            Log.d("Situm>", "\tAlready loaded, library = $library")
+            Log.d(TAG, "\tAlready loaded, library = $library")
             library?.let {
                 callback.onSuccess(it)
             }
             return
         }
         loaded = true // Set loaded=true as soon as possible to avoid multiple calls while loading.
-        Log.d("Situm>", "\tNot loaded yet.")
+        Log.d(TAG, "\tNot loaded yet.")
         // Avoid race conditions: native load will be called when the target view was available.
         // The SitumMapsLibrary instantiation must be done immediately so it can be passed as
         // parameter in the callback above while loading (when multiple calls to load() occur).
@@ -49,7 +51,7 @@ class SitumMapLibraryLoader private constructor(
             library?.apply {
                 setSitumMapsListener(object : SitumMapsListener {
                     override fun onSuccess() {
-                        Log.d("Situm>", "\tNative load done.")
+                        Log.d(TAG, "\tNative load done.")
                         onLibraryLoaded(this@apply, flutterLibrarySettings, callback)
                     }
 
@@ -78,7 +80,7 @@ class SitumMapLibraryLoader private constructor(
             override fun run() {
                 val mapView = activity.findViewById<View>(R.id.situm_flutter_map_view)
                 if (mapView != null) {
-                    Log.d("Situm>", "Target view found: ${R.id.situm_flutter_map_view}.")
+                    Log.d(TAG, "Target view found: ${R.id.situm_flutter_map_view}.")
                     handler.post(runnable)
                 } else {
                     handler.postDelayed(this, 50)
@@ -111,7 +113,7 @@ class SitumMapLibraryLoader private constructor(
         try {
             library?.unload()
         } catch (e: IllegalStateException) {
-            Log.d("Situm>", "Illegal call to unload()", e)
+            Log.d(TAG, "Illegal call to unload()", e)
         }
         library = null
         loaded = false

--- a/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/SitumMapLibraryLoader.kt
+++ b/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/SitumMapLibraryLoader.kt
@@ -8,34 +8,48 @@ import es.situm.wayfinding.SitumMapsLibrary
 import es.situm.wayfinding.SitumMapsListener
 import es.situm.wayfinding.actions.ActionsCallback
 
-class SitumMapLibraryLoader(
-    private val activity: AppCompatActivity,
+class SitumMapLibraryLoader private constructor(
+    private var activity: AppCompatActivity,
 ) {
 
     companion object {
         var loaded = false
         private var library: SitumMapsLibrary? = null
+        private var instance: SitumMapLibraryLoader? = null
+
+        fun fromActivity(activity: AppCompatActivity): SitumMapLibraryLoader {
+            instance = instance ?: SitumMapLibraryLoader(activity)
+            instance!!.activity = activity
+            return instance!!
+        }
     }
 
     private val handler = android.os.Handler(Looper.getMainLooper())
 
     fun load(flutterLibrarySettings: FlutterLibrarySettings, callback: Callback) {
-        if (loaded) {
+        Log.d("Situm>", "PlatformView load called!")
+        if (loaded) { // Manage this case, but it should not happen.
+            Log.d("Situm>", "\tAlready loaded, library = $library")
             library?.let {
                 callback.onSuccess(it)
             }
             return
         }
-
-        Log.d("ATAG", "PlatformView load called!")
+        loaded = true // Set loaded=true as soon as possible to avoid multiple calls while loading.
+        Log.d("Situm>", "\tNot loaded yet.")
+        // Avoid race conditions: native load will be called when the target view was available.
+        // The SitumMapsLibrary instantiation must be done immediately so it can be passed as
+        // parameter in the callback above while loading (when multiple calls to load() occur).
+        library = SitumMapsLibrary(
+            R.id.situm_flutter_map_view,
+            activity,
+            flutterLibrarySettings.librarySettings
+        )
         runLoad {
-            library = SitumMapsLibrary(
-                R.id.situm_flutter_map_view,
-                activity,
-                flutterLibrarySettings.librarySettings
-            ).apply {
+            library?.apply {
                 setSitumMapsListener(object : SitumMapsListener {
                     override fun onSuccess() {
+                        Log.d("Situm>", "\tNative load done.")
                         onLibraryLoaded(this@apply, flutterLibrarySettings, callback)
                     }
 
@@ -49,7 +63,6 @@ class SitumMapLibraryLoader(
                 // Situm Maps Library load!
                 load()
             }
-            loaded = true
         }
     }
 
@@ -65,10 +78,9 @@ class SitumMapLibraryLoader(
             override fun run() {
                 val mapView = activity.findViewById<View>(R.id.situm_flutter_map_view)
                 if (mapView != null) {
-                    Log.d("ATAG", "Target view found: ${R.id.situm_flutter_map_view}.")
+                    Log.d("Situm>", "Target view found: ${R.id.situm_flutter_map_view}.")
                     handler.post(runnable)
                 } else {
-                    Log.d("ATAG", "No target view available, waiting.")
                     handler.postDelayed(this, 50)
                 }
             }
@@ -96,9 +108,13 @@ class SitumMapLibraryLoader(
     }
 
     fun unload() {
-        loaded = false
-        // TODO: library.unload() crashes here.
+        try {
+            library?.unload()
+        } catch (e: IllegalStateException) {
+            Log.d("Situm>", "Illegal call to unload()", e)
+        }
         library = null
+        loaded = false
     }
 
     interface Callback {

--- a/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/SitumMapPlatformView.kt
+++ b/android/src/main/kotlin/com/situm/situm_flutter_wayfinding/SitumMapPlatformView.kt
@@ -29,6 +29,8 @@ class SitumMapPlatformView(
     DefaultLifecycleObserver {
 
     companion object {
+        const val TAG = "Situm>"
+
         // Workaround to avoid WYF to be recreated with the flutter widget lifecycle.
         @SuppressLint("StaticFieldLeak")
         private var layout: View? = null
@@ -103,7 +105,7 @@ class SitumMapPlatformView(
     }
 
     private fun unload(methodResult: MethodChannel.Result?) {
-        Log.d("Situm>", "PlatformView unload called!")
+        Log.d(TAG, "PlatformView unload called!")
         libraryLoader.unload()
         // Ensure this layout does not have a parent:
         if (layout?.parent != null) {
@@ -123,7 +125,7 @@ class SitumMapPlatformView(
 
     // Select the given poi in the map.
     private fun selectPoi(arguments: Map<String, Any>, methodResult: MethodChannel.Result) {
-        Log.d("Situm>", "Android> Plugin selectPoi call.")
+        Log.d(TAG, "Android> Plugin selectPoi call.")
         val buildingId = arguments["buildingId"] as String
         val poiId = arguments["id"] as String
         FlutterCommunicationManager.fetchPoi(
@@ -131,16 +133,17 @@ class SitumMapPlatformView(
             poiId,
             object : FlutterCommunicationManager.Callback<Poi> {
                 override fun onSuccess(result: Poi) {
-                    Log.d("Situm>", "Android> Library selectPoi call.")
+                    Log.d(TAG, "Android> Library selectPoi call.")
                     library?.selectPoi(result, object : ActionsCallback {
                         override fun onActionConcluded() {
-                            Log.d("Situm>", "Android> selectPoi success.")
+                            Log.d(TAG, "Android> selectPoi success.")
                             methodResult.success(poiId)
                         }
                     })
                 }
 
                 override fun onError(message: String) {
+                    Log.e(TAG, "Android> Library selectPoi error: $message.")
                     methodResult.error(ERROR_SELECT_POI, message, null)
                 }
             })

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -6,22 +6,34 @@ class SitumFlutterWayfinding {
   OnPoiSelectedCallback? onPoiSelectedCallback;
   OnPoiDeselectedCallback? onPoiDeselectedCallback;
 
-  SitumFlutterWayfinding(int id) {
-    methodChannel = MethodChannel('${CHANNEL_ID}_$id');
+  static final SitumFlutterWayfinding _controller =
+      SitumFlutterWayfinding._internal();
+
+  factory SitumFlutterWayfinding() {
+    // Factory: ensure only one controller exists.
+    return _controller;
+  }
+
+  SitumFlutterWayfinding._internal() {
+    methodChannel = const MethodChannel(CHANNEL_ID);
     methodChannel.setMethodCallHandler(_methodCallHandler);
   }
 
   // Calls:
 
   Future<String?> load(
-    SitumMapViewCallback situmMapLoadCallback,
-    SitumMapViewCallback? situmMapDidUpdateCallback,
-    Map<String, dynamic> creationParams
-  ) async {
-    print("Situm> Dart load called, methodChannel will be invoked.");
-    final result = await methodChannel.invokeMethod<String>('load', creationParams);
-    print("Situm> Got load result: $result");
+      SitumMapViewCallback situmMapLoadCallback,
+      SitumMapViewCallback? situmMapDidUpdateCallback,
+      Map<String, dynamic> creationParams) async {
+    print("Situm> Dart load() invoked.");
+    if (situmMapLoaded) {
+      return "ALREADY_DONE";
+    }
+    print("Situm> MethodChannel will be invoked.");
     situmMapLoaded = true;
+    final result =
+        await methodChannel.invokeMethod<String>('load', creationParams);
+    print("Situm> Got load result: $result");
     situmMapLoadCallback(this);
     situmMapDidUpdateCallback?.call(this);
     return result;
@@ -34,8 +46,8 @@ class SitumFlutterWayfinding {
 
   Future<String?> selectPoi(String id, String buildingId) async {
     log("Dart selectPoi called, methodChannel will be invoked.");
-    return await methodChannel.invokeMethod<String>('selectPoi',
-        <String, dynamic>{'id': id, 'buildingId': buildingId});
+    return await methodChannel.invokeMethod<String>(
+        'selectPoi', <String, dynamic>{'id': id, 'buildingId': buildingId});
   }
 
   Future<String?> startPositioning() async {

--- a/lib/src/situm_map_view.dart
+++ b/lib/src/situm_map_view.dart
@@ -83,7 +83,7 @@ class _SitumMapViewState extends State<SitumMapView> {
       "showNavigationIndications": widget.showNavigationIndications,
       "showFloorSelector": widget.showFloorSelector,
     };
-    controller = SitumFlutterWayfinding(id);
+    controller = SitumFlutterWayfinding();
     controller!.load(widget.loadCallback, widget.didUpdateCallback, loadParams);
   }
 


### PR DESCRIPTION
Engado un factory constructor ao controlador de WYF, asegurando que só unha instancia deste vivirá de cada vez.
Fago que as chamadas a load só cheguen a nativo 1 vez. Para que volva a chegar, o módulo debe ser descargado (ben por chamada a método ou ben por descarga da propia platform-view).
Corrixo as chamadas a unload para facelas máis seguras, xa que o ciclo de vida da platform-view pode dar problemas.
